### PR TITLE
Add widget tree monitoring to widget watcher

### DIFF
--- a/lib/services/widget_monitor_service.dart
+++ b/lib/services/widget_monitor_service.dart
@@ -2,6 +2,6 @@ import 'package:example/models/widget_description.dart';
 
 class WidgetMonitorService {
   void addWidget(WidgetDescription widget) {
-    print('🍬 WidgeMonitorService - addWidget: $widget');
+    print('🍬 WidgetMonitorService - addWidget: $widget');
   }
 }

--- a/lib/ui/utils/widget_emitter/widget_watcher.dart
+++ b/lib/ui/utils/widget_emitter/widget_watcher.dart
@@ -2,10 +2,13 @@ import 'package:example/app/app.locator.dart';
 import 'package:example/enum/widget_type.dart';
 import 'package:example/models/widget_description.dart';
 import 'package:example/services/widget_monitor_service.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:stacked_services/stacked_services.dart';
 
 class WidgetWatcher extends StatefulWidget {
   final Widget child;
+
   WidgetWatcher({Key? key, required this.child}) : super(key: key);
 
   @override
@@ -14,6 +17,10 @@ class WidgetWatcher extends StatefulWidget {
 
 class _WidgetWatcherState extends State<WidgetWatcher> {
   final widgetMonitorService = locator<WidgetMonitorService>();
+
+  /// A set of element IDs that have already been scanned.
+  final Set<int> _scannedElementIds = {};
+
   @override
   Widget build(BuildContext context) {
     return widget.child;
@@ -22,22 +29,64 @@ class _WidgetWatcherState extends State<WidgetWatcher> {
   @override
   void initState() {
     super.initState();
+    _scanWidgetTree();
+  }
 
-    WidgetDescription widgetFound = WidgetDescription(
-      type: WidgetType.touchable,
-      position: Offset.zero,
-      size: Size.zero,
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _scanWidgetTree();
+  }
+
+  void _scanWidgetTree() {
+    // Re-scan the widget tree when the dependencies change.
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => context.visitChildElements(_recursiveVisitor),
     );
+  }
 
-    // TASK: Listen to widgets here (or anywhere besides the UI files) and pass it to the widget monitor service
-    //
-    // NON-NEGOTIABLE IMPLEMENTATION RULES:
-    // 1. Widgets should be added as they appear in the widget tree (tap "get started button to add and remove widgets")
-    // 2. No code to be added in any of the UI files (this code will eventually be used in a package)
-    // 2. The same widget should not be added twice
-    // 3. We want to get the position, size and type of widget
-    // 4. We should detect all tappable widgets, all input/text fields, all scrollable widgets
+  void _recursiveVisitor(Element element) {
+    // Get the element's identity hash code. This is used to determine if the
+    // element has already been scanned. The identityHashCode of an object is
+    // guaranteed to be unique for each instance of an object for the duration
+    // of a Dart program’s execution. Unlike the key, the identity hash code
+    // exists always, so it is stable across widget rebuilds.
+    final elementId = identityHashCode(element);
 
-    widgetMonitorService.addWidget(widgetFound);
+    // Only scan unique elements.
+    if (!_scannedElementIds.contains(elementId)) {
+      _scannedElementIds.add(elementId);
+
+      final renderBox = element.findRenderObject() as RenderBox?;
+      if (renderBox != null && renderBox.hasSize) {
+        final Offset position = renderBox.localToGlobal(Offset.zero);
+        final Size size = renderBox.size;
+
+        // Check the widget type
+        WidgetType? type;
+        if (element.widget is GestureDetector || element.widget is InkWell) {
+          type = WidgetType.touchable;
+        } else if (element.widget is ScrollView ||
+            element.widget is Scrollable) {
+          type = WidgetType.scrollable;
+        } else if (element.widget is TextField ||
+            element.widget is TextFormField ||
+            element.widget is CupertinoTextField) {
+          type = WidgetType.input;
+        }
+
+        if (type != null) {
+          final WidgetDescription widgetFound = WidgetDescription(
+            type: type,
+            position: position,
+            size: size,
+          );
+          widgetMonitorService.addWidget(widgetFound);
+        }
+      }
+
+      // Recurse to children
+      element.visitChildren(_recursiveVisitor);
+    }
   }
 }


### PR DESCRIPTION
I have followed all instruction and met the following requirements successfully:

- [X] Traverse the widget tree under WidgetWatcher efficiently.
- [X] Scan the widget tree and pass back the description of all widgets that are [tappable, scrollable, inputable].
- [X] Perform the scan only once per unique widget
- [X] Add newer widgets to monitor if they have become visible due to any children update in the tree.
- [X] Add any new widgets that appear on a newly navigated page.
- [X] Add explanatory comments and documentation.

Explanation:
It uses the method on the context to traverse all the elements and scans each of them for the required properties. It performs the same scan recursively on children on each element and so on. Along the way it adds every scanned element to a dictionary for caching. This is essential to reduce useless computations during each ticker update.

- Reason for using ticker
Flutter doesn't have a way for a parent widget to listen to the changes in child widgets. This makes it impossible to re-scan the tree when a child updates. Hence, we use the concept of polling to keep the scan running periodically on every frame using a Ticker. Anytime a child updates, the next scan is able to pick up new widgets. Moreover, this solution also covers navigational changes without using any extra navigation observers.

As for the performance concern, the expensive step is findingRenderObject of the element. However, this method only runs the first time and then elements are cached. So on the next ticker scan this expensive method is not run.

I have made two recording one with keys attached to all the widgets for easier readability in the console. And a second recording with original settings just as stated in the requirements.

# With Keys 
https://github.com/FilledStacks/widget_tree_bounty/assets/62943972/914d4874-0d79-4056-a855-46c0dda455f8

# Original requirements 
https://github.com/FilledStacks/widget_tree_bounty/assets/62943972/b5efe8f7-4baa-472d-b66f-158d95e3d9ba

